### PR TITLE
DacDeploy - additional error handling

### DIFF
--- a/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
+++ b/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
@@ -256,20 +256,36 @@ function DeployDac([string] $databaseName, [string]$connectionString, [string]$s
 
     $dacServicesObject = new-object Microsoft.SqlServer.Dac.DacServices ($connectionString)
 
-    $dacpacInstance = [Microsoft.SqlServer.Dac.DacPackage]::Load($dacpacPath)
-
     try
     {
-        $dacServicesObject.Deploy($dacpacInstance, $databaseName,$true) 
-
-        $dacServicesObject.Register($databaseName, $dacpacApplicationName,$defaultDacPacApplicationVersion)
-
-        Write-Verbose("Dac Deployed")
+        $dacpacInstance = [Microsoft.SqlServer.Dac.DacPackage]::Load($dacpacPath)
     }
     catch
     {
-        Write-Verbose("Dac Deploy Failed")
+        Write-Verbose("Unable to load dacpac, error: $_")  
+        return    
     }
+    
+    try
+    {
+        $dacServicesObject.Deploy($dacpacInstance, $databaseName,$true)        
+    }
+    catch
+    {
+        Write-Verbose("Dac Deploy Failed, error: $_")
+        return
+    }
+    
+    try
+    {        
+        $dacServicesObject.Register($databaseName, $dacpacApplicationName,$defaultDacPacApplicationVersion)
+        Write-Verbose("Dac Deployed and Registered")    
+    }
+    catch
+    {
+        Write-Verbose("Dac Registration Failed, error: $_")
+    }
+    
 }
 
 function CreateDb([string] $databaseName, [string]$connectionString)


### PR DESCRIPTION
Split out dacpac load, deploy + register to show where a failure occurs and added exception message to output.

Split the calls to load a dacpac, deploy and then register into three separate try catch blocks so it is possible to tell where in the process the deploy failed and also added the exception message as this is really needed to debug any failures.

This follows on from https://github.com/PowerShell/xDatabase/issues/9
