### PR TITLE
Added logging for when dac deploy fails

### DIFF
--- a/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
+++ b/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
@@ -268,7 +268,8 @@ function DeployDac([string] $databaseName, [string]$connectionString, [string]$s
     }
     catch
     {
-        Write-Verbose("Dac Deploy Failed")
+        $errorMessage = $_.Exception.Message
+        Write-Verbose('Dac Deploy Failed: ''{0}''' -f $errorMessage)
     }
 }
 


### PR DESCRIPTION
We were trying to deploy a DAC using DSC but it kept failing without giving any reason, so we added 'logging' to the resource.

This gives back the reason for the failing of the DAC deployment in the console output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdatabase/27)
<!-- Reviewable:end -->
