### PR TITLE
Adds SQL 2017 support

### DIFF
--- a/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.psm1
+++ b/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.psm1
@@ -22,7 +22,7 @@ function Get-TargetResource
         $Type,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion
     )
@@ -54,7 +54,7 @@ function Set-TargetResource
         $Type,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion
     )
@@ -102,7 +102,7 @@ function Test-TargetResource
         $Type,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion
     )
@@ -235,6 +235,10 @@ function Get-SqlServerMajoreVersion([string]$sqlServerVersion)
         "2016"
         {
             $majorVersion = 130
+        }
+        "2017"
+        {
+            $majorVersion = 140
         }
     }
 

--- a/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.psm1
+++ b/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.psm1
@@ -1,3 +1,4 @@
+Import-Module -DisableNameChecking $PSScriptRoot\..\xDatabase_Common
 function Get-TargetResource
 {
     [CmdletBinding()]
@@ -214,35 +215,6 @@ function Load-DacFx([string]$sqlserverVersion)
     {
         Throw "Loading DacFx Failed"
     }
-}
-
-function Get-SqlServerMajoreVersion([string]$sqlServerVersion)
-{
-    switch($sqlserverVersion)
-    {
-        "2008-R2"
-        {
-            $majorVersion = 100
-        }
-        "2012"
-        {
-            $majorVersion = 110
-        }
-        "2014"
-        {
-            $majorVersion = 120
-        }
-        "2016"
-        {
-            $majorVersion = 130
-        }
-        "2017"
-        {
-            $majorVersion = 140
-        }
-    }
-
-    return $majorVersion
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.schema.mof
+++ b/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.schema.mof
@@ -7,7 +7,7 @@ class MSFT_xDBPackage : OMI_BaseResource
     [Required, Description("Sql Server Name")] String SqlServer;
     [Required, Description("Path to BacPac/DacPac")] String Path;
     [Required, Description("Type for backup(Extract id done for DACPAC and Import for BACPAC)"), ValueMap{"DACPAC","BACPAC"}, Values{"DACPAC","BACPAC"}] String Type;
-    [Required, ValueMap{"2008-R2","2012","2014","2016","2017"}, Values{"2008-R2","2012","2014","2016"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
+    [Required, ValueMap{"2008-R2","2012","2014","2016","2017"}, Values{"2008-R2","2012","2014","2016","2017"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
 };
 
 

--- a/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.schema.mof
+++ b/DSCResources/MSFT_xDBPackage/MSFT_xDBPackage.schema.mof
@@ -7,7 +7,7 @@ class MSFT_xDBPackage : OMI_BaseResource
     [Required, Description("Sql Server Name")] String SqlServer;
     [Required, Description("Path to BacPac/DacPac")] String Path;
     [Required, Description("Type for backup(Extract id done for DACPAC and Import for BACPAC)"), ValueMap{"DACPAC","BACPAC"}, Values{"DACPAC","BACPAC"}] String Type;
-    [Required, ValueMap{"2008-R2","2012","2014","2016"}, Values{"2008-R2","2012","2014","2016"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
+    [Required, ValueMap{"2008-R2","2012","2014","2016","2017"}, Values{"2008-R2","2012","2014","2016"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
 };
 
 

--- a/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
+++ b/DSCResources/MSFT_xDatabase/MSFT_xDatabase.psm1
@@ -28,7 +28,7 @@ function Get-TargetResource
         $SqlServer,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion,
 
@@ -75,7 +75,7 @@ function Set-TargetResource
         $SqlServer,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion,
 
@@ -148,7 +148,7 @@ function Test-TargetResource
         $SqlServer,
 
         [parameter(Mandatory = $true)]
-        [ValidateSet("2008-R2","2012","2014","2016")]
+        [ValidateSet("2008-R2","2012","2014","2016","2017")]
         [System.String]
         $SqlServerVersion,
 

--- a/DSCResources/MSFT_xDatabase/MSFT_xDatabase.schema.mof
+++ b/DSCResources/MSFT_xDatabase/MSFT_xDatabase.schema.mof
@@ -5,7 +5,7 @@ class MSFT_xDatabase : OMI_BaseResource
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credentials to Connect to the sql server")] String Credentials;
     [Required, ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
     [Write, Description("Sql Server Name")] String SqlServer;
-    [Required, ValueMap{"2008-R2","2012","2014","2016"}, Values{"2008-R2","2012","2014","2016"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
+    [Required, ValueMap{"2008-R2","2012","2014","2016","2017"}, Values{"2008-R2","2012","2014","2016","2017"}, Description("Sql Server Version For DacFx")] String SqlServerVersion;
     [Write, Description("Path to BacPac, if this is specified resore is performed")] String BacPacPath;
     [Key, Description("Name of the Database")] String DatabaseName;
     [Write, Description("Path to DacPac, if this is specified dacpac deployment is performed")] String DacPacPath;

--- a/DSCResources/xDatabase_Common/xDatabase_Common.psm1
+++ b/DSCResources/xDatabase_Common/xDatabase_Common.psm1
@@ -227,6 +227,10 @@ function Get-SqlServerMajoreVersion([string]$sqlServerVersion)
         {
             $majorVersion = 130
         }
+        "2017"
+        {
+            $majorVersion = 140
+        }
     }
 
     return $majorVersion

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿[![Build status](https://ci.appveyor.com/api/projects/status/oidqwkp7ljqoefd3/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdatabase/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/oidqwkp7ljqoefd3/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdatabase/branch/master)
 
 # xDatabase
 
@@ -11,6 +11,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Contributing
+
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
 ## Resources

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/oidqwkp7ljqoefd3/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdatabase/branch/master)
+﻿[![Build status](https://ci.appveyor.com/api/projects/status/oidqwkp7ljqoefd3/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdatabase/branch/master)
 
 # xDatabase
 
@@ -23,7 +23,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Credentials**: The credential to connect to the SQL server.
 * **SqlServer**: The SQL server.
 * **SqlServerVersion**: The version of the SQL Server.
-This property can take the following values: { 2008-R2 | 2012 | 2014 }
+This property can take the following values: { 2008-R2 | 2012 | 2014 | 2016 | 2017 }
 * **BacPacPath**: The path to the .bacpac file to be used for database restore
 If this is used, the DacPacPath (see below) cannot be specified.
 * **DacPacPath**: The path to the .dacpac file to be used for database schema deploy.
@@ -38,17 +38,22 @@ This must specified if DacPacPath is provided.
 
 * **DatabaseName**: The name of the database to be deployed.
 * **SqlServer**: The SQL server.
-* **SqlServerVersion**: The version of the SQL Server. 
-This property can take the following values: { 2008-R2 | 2012 | 2014 }
+* **SqlServerVersion**: The version of the SQL Server.
+This property can take the following values: { 2008-R2 | 2012 | 2014 | 2016 | 2017 }
 * **Path**: The path to the .bacpac or .dacpac file to be used to export a database to a bacpac or extract a db to a dacpac respectively.
 * **Type**: This property can take the following values for dacpac extraction and bacpac export: { DACPAC | BACPAC }
-
 
 ## Versions
 
 ### Unreleased
 
+### 1.8.0.0
+
+* Added support for SQL Server 2017
+* xDBPackage now uses the shared function to identify the paths for the different SQL server versions
+
 ### 1.7.0.0
+
 * Added support SQL Server 2016
 
 ### 1.6.0.0
@@ -80,10 +85,9 @@ This property can take the following values: { 2008-R2 | 2012 | 2014 }
 
 ### 1.0.0.0
 
-* Initial release with the following resources 
-    * xDatabase
-    * xDBPackage
-
+* Initial release with the following resources
+  * xDatabase
+  * xDBPackage
 
 ## Examples
 

--- a/Tests/Unit/MSFT_xDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xDatabase.Tests.ps1
@@ -6,7 +6,7 @@ $common = "..\..\DSCResources\xDatabase_Common\xDatabase_Common.psm1"
 $testParameter = @{
     Ensure = "Present"
     SqlServer = "localhost"
-    SqlServerVersion = "2016"
+    SqlServerVersion = "2017"
     DatabaseName = "test"
 }
 

--- a/Tests/Unit/MSFT_xDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xDatabase.Tests.ps1
@@ -13,8 +13,7 @@ foreach ($sqlServerVersion in $sqlServerVersions)
     DatabaseName = "test"
   }
 
-  Describe "Testing xDatabase resource execution"
-  {
+  Describe "Testing xDatabase resource execution" {
     Copy-Item -Path "$here\$source" -Destination TestDrive:\script.ps1
     Copy-Item -Path "$here\$common" -Destination TestDrive:\helper.ps1
 
@@ -28,24 +27,19 @@ foreach ($sqlServerVersion in $sqlServerVersions)
     . TestDrive:\script.ps1
     . TestDrive:\helper.ps1
 
-    It "Get-TargetResource should return [Hashtable]"
-    {
+    It "Get-TargetResource should return [Hashtable]" {
       (Get-TargetResource @testParameter).GetType()  -as [String] | Should Be "hashtable"
     }
 
-    Context "database does not exist"
-    {
+    Context "database does not exist" {
       $connectionObj | Add-Member -MemberType ScriptMethod -Name Open -Value {throw [System.Data.SqlClient.SqlException]}
-      It "Test-TargetResource should return false"
-      {
+      It "Test-TargetResource should return false" {
         Test-TargetResource @testParameter | Should Be $false
       }
     }
-    Context "database does exist"
-    {
+    Context "database does exist" {
         $connectionObj | Add-Member -MemberType ScriptMethod -Name Open -Value {return $null} -Force
-      It "Test-TargetResource should return false"
-      {
+      It "Test-TargetResource should return false" {
         Test-TargetResource @testParameter | Should Be $true
       }
     }

--- a/Tests/Unit/MSFT_xDatabase.Tests.ps1
+++ b/Tests/Unit/MSFT_xDatabase.Tests.ps1
@@ -2,15 +2,19 @@ $here = Split-Path -Parent $MyInvocation.MyCommand.Path
 $leaf = Split-Path -Leaf $MyInvocation.MyCommand.Path
 $source = "..\..\DSCResources\$($leaf.Split(".")[0])\$($leaf -replace ".Tests.ps1$",".psm1")"
 $common = "..\..\DSCResources\xDatabase_Common\xDatabase_Common.psm1"
+$sqlServerVersions = '2008-R2','2012','2014','2016','2017'
 
-$testParameter = @{
+foreach ($sqlServerVersion in $sqlServerVersions)
+{
+  $testParameter = @{
     Ensure = "Present"
     SqlServer = "localhost"
-    SqlServerVersion = "2017"
+    SqlServerVersion = $sqlServerVersion
     DatabaseName = "test"
-}
+  }
 
-Describe "Testing xDatabase resource execution" {
+  Describe "Testing xDatabase resource execution"
+  {
     Copy-Item -Path "$here\$source" -Destination TestDrive:\script.ps1
     Copy-Item -Path "$here\$common" -Destination TestDrive:\helper.ps1
 
@@ -24,21 +28,26 @@ Describe "Testing xDatabase resource execution" {
     . TestDrive:\script.ps1
     . TestDrive:\helper.ps1
 
-    It "Get-TargetResource should return [Hashtable]" {
-        (Get-TargetResource @testParameter).GetType()  -as [String] | Should Be "hashtable"
+    It "Get-TargetResource should return [Hashtable]"
+    {
+      (Get-TargetResource @testParameter).GetType()  -as [String] | Should Be "hashtable"
     }
-    Context "database does not exist" {
 
-        $connectionObj | Add-Member -MemberType ScriptMethod -Name Open -Value {throw [System.Data.SqlClient.SqlException]}
-        It "Test-TargetResource should return false" {
-            Test-TargetResource @testParameter | Should Be $false
-        }
+    Context "database does not exist"
+    {
+      $connectionObj | Add-Member -MemberType ScriptMethod -Name Open -Value {throw [System.Data.SqlClient.SqlException]}
+      It "Test-TargetResource should return false"
+      {
+        Test-TargetResource @testParameter | Should Be $false
+      }
     }
-    Context "database does exist" {
-
+    Context "database does exist"
+    {
         $connectionObj | Add-Member -MemberType ScriptMethod -Name Open -Value {return $null} -Force
-        It "Test-TargetResource should return false" {
-            Test-TargetResource @testParameter | Should Be $true
-        }
+      It "Test-TargetResource should return false"
+      {
+        Test-TargetResource @testParameter | Should Be $true
+      }
     }
+  }
 }


### PR DESCRIPTION
Adds support for finding the SQL 2017 Dac tools either on a SQL server 2017 installation or a box that has the 2017 management tools installed.

Issues this addresses:
https://github.com/PowerShell/xDatabase/issues/37
https://github.com/PowerShell/xDatabase/issues/34

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdatabase/38)
<!-- Reviewable:end -->
